### PR TITLE
Prevent fade from freezing with the main thread

### DIFF
--- a/Distrib/CephalopodDistrib.swift
+++ b/Distrib/CephalopodDistrib.swift
@@ -61,28 +61,40 @@ final class AutoCancellingTimer {
 
 final class AutoCancellingTimerInstance: NSObject {
   private let repeats: Bool
-  private var timer: Timer?
-  private var callback: ()->()
-  
-  init(interval: TimeInterval, repeats: Bool = false, callback: @escaping ()->()) {
+  private var callback: () -> Void
+  private var interval: TimeInterval
+  private var workItem: DispatchWorkItem?
+
+  init(interval: TimeInterval, repeats: Bool = false, callback: @escaping () -> Void) {
     self.repeats = repeats
     self.callback = callback
-    
+    self.interval = interval
+
     super.init()
-    
-    timer = Timer.scheduledTimer(timeInterval: interval, target: self,
-                                 selector: #selector(AutoCancellingTimerInstance.timerFired(_:)), userInfo: nil, repeats: repeats)
+
+    scheduleTimer()
   }
-  
+
   func cancel() {
-    timer?.invalidate()
+    workItem?.cancel()
   }
-  
-  @objc func timerFired(_ timer: Timer) {
+
+  private func scheduleTimer() {
+    let workItem = DispatchWorkItem { [weak self] in
+      self?.timerFired()
+    }
+    self.workItem = workItem
+
+    cephalopodDispatchQueue.asyncAfter(deadline: .now() + .microseconds(Int(interval * 1_000_000)), execute: workItem)
+  }
+
+  func timerFired() {
     self.callback()
-    if !repeats { cancel() }
+    if repeats { scheduleTimer() }
   }
 }
+
+let cephalopodDispatchQueue = DispatchQueue(label: "Cephalopod Queue")
 
 
 // ----------------------------


### PR DESCRIPTION
Before this change the `Timer` would run on the main thread, meaning if your UI froze, so did the audio fade. [Grand Central Dispatch](https://developer.apple.com/documentation/DISPATCH) allows it to run on a background thread as well run [much more efficiently](https://developer.apple.com/library/content/documentation/Performance/Conceptual/EnergyGuide-iOS/MinimizeTimerUse.html).

This simply converts `AutoCancellingTimerInstance`  to use `DispatchQueue` instead of `Timer`.